### PR TITLE
Fix 'rught' typo

### DIFF
--- a/addon/components/Main.lua
+++ b/addon/components/Main.lua
@@ -513,7 +513,7 @@ function MinArch:KeystoneTooltip(self, raceID)
 	GameTooltip:AddLine("You have "..artifact['heldKeystones'].." "..tostring(name)..plural .. " in your bags", GRAY_FONT_COLOR.r, GRAY_FONT_COLOR.g, GRAY_FONT_COLOR.b, 1);
 	GameTooltip:AddLine(" ");
 	GameTooltip:AddLine("Left click to apply a keystone");
-	GameTooltip:AddLine("Rught click to remove a keystone");
+	GameTooltip:AddLine("Right click to remove a keystone");
 	GameTooltip:Show();
 end
 


### PR DESCRIPTION
### What does this PR do?

- Fixes a typo in the user interface where "Right" was misspelled as "Rught".