### PR TITLE
History: implement total sold price display for race statistics

### DIFF
--- a/addon/components/History.lua
+++ b/addon/components/History.lua
@@ -716,6 +716,7 @@ function MinArch:CreateHistoryList(RaceID, caller)
     local count = 0
     local sumComplete = 0
     local sumTotalComplete = 0
+    local sumTotalSoldPrice = 0
 
     for _, gparams in ipairs(groups) do
         for itemid, details in pairs(MinArchHistDB[RaceID]) do
@@ -806,6 +807,7 @@ function MinArch:CreateHistoryList(RaceID, caller)
                     if details.totalcomplete > 0 then
                         sumComplete = sumComplete + 1
                         sumTotalComplete = sumTotalComplete + details.totalcomplete
+                        sumTotalSoldPrice = sumTotalSoldPrice + details.sellprice * details.totalcomplete
                     end
                 end
 
@@ -843,7 +845,8 @@ function MinArch:CreateHistoryList(RaceID, caller)
         end
     end
 
-    MinArchHist.statsFrame.text:SetText('Progress: ' .. sumComplete .. '/' .. count .. ' - Total: ' .. sumTotalComplete)
+    sumTotalSoldPrice = math.floor(sumTotalSoldPrice / 10000)
+    MinArchHist.statsFrame.text:SetText('Progress: ' .. sumComplete .. '/' .. count .. ' - Total: ' .. sumTotalComplete .. ' (' .. sumTotalSoldPrice .. 'g)')
 
     -- Set the size of the scroll child
     if height > 2 then


### PR DESCRIPTION
### What does this PR do?
This PR implements feature that calculates total value of crafted items in gold and shows it in each race statistics

Showcase:
<img width="327" alt="image" src="https://github.com/MrFox42/minarch/assets/40148652/4a419ee7-f8ac-4ecf-9984-aa53fc991b96">


